### PR TITLE
feat: quick and dirty hack for target language code (Google Translate only)

### DIFF
--- a/TranslateTitlesCN/configure.phtml
+++ b/TranslateTitlesCN/configure.phtml
@@ -40,6 +40,13 @@
             <input id="libre-api-key" name="LibreApiKey" type="text" value="<?php echo FreshRSS_Context::$user_conf->LibreApiKey; ?>">
         </div>
     </div>
+    <div class="form-group">
+        <label class="group-name" for="target-language">Target language code:</label>
+        <div class="group-controls">
+            <input id="target-language-code" name="TargetLanguageCode" type="text" value="<?php echo FreshRSS_Context::$user_conf->TargetLanguageCode; ?>">
+        </div>
+    </div>
+
 
     <!-- 订阅源翻译设置 -->
     <div class="form-group">

--- a/TranslateTitlesCN/extension.php
+++ b/TranslateTitlesCN/extension.php
@@ -41,6 +41,10 @@ class TranslateTitlesExtension extends Minz_Extension {
         if (is_null(FreshRSS_Context::$user_conf->LibreApiKey)) {
             FreshRSS_Context::$user_conf->LibreApiKey = '';
         }
+        if (is_null(FreshRSS_Context::$user_conf->TargetLanguageCode)) {
+            FreshRSS_Context::$user_conf->TargetLanguageCode = 'zh';
+        }
+
 
         FreshRSS_Context::$user_conf->save();
 
@@ -73,6 +77,10 @@ class TranslateTitlesExtension extends Minz_Extension {
 
             $libreApiKey = Minz_Request::param('LibreApiKey', '');
             FreshRSS_Context::$user_conf->LibreApiKey = $libreApiKey;
+
+            $targetLanguageCode = Minz_Request::param('TargetLanguageCode', '');
+            FreshRSS_Context::$user_conf->TargetLanguageCode = $targetLanguageCode;
+
 
             // 保存并记录结果
             $saveResult = FreshRSS_Context::$user_conf->save();

--- a/TranslateTitlesCN/lib/TranslationService.php
+++ b/TranslateTitlesCN/lib/TranslationService.php
@@ -5,6 +5,7 @@ class TranslationService {
     private $googleBaseUrl;
     private $libreBaseUrl;
     private $libreApiKey;
+    private $targetLanguageCode;
 
     public function __construct($serviceType) {
         $this->serviceType = $serviceType;
@@ -12,6 +13,7 @@ class TranslationService {
         $this->googleBaseUrl = 'https://translate.googleapis.com/translate_a/single';
         $this->libreBaseUrl = FreshRSS_Context::$user_conf->LibreApiUrl;
         $this->libreApiKey = FreshRSS_Context::$user_conf->LibreApiKey;
+        $this->targetLanguageCode = FreshRSS_Context::$user_conf->TargetLanguageCode;
     }
 
     public function translate($text) {
@@ -114,7 +116,7 @@ class TranslationService {
         $queryParams = http_build_query([
             'client' => 'gtx',
             'sl' => 'auto',     // 源语言设置为自动检测
-            'tl' => 'zh',       // 目标语言设置为中文
+            'tl' => $this->targetLanguageCode?$this->targetLanguageCode:'zh',       // 目标语言设置为中文
             'dt' => 't',
             'q' => $text,
         ]);


### PR DESCRIPTION
I implemented a quick hack addressing the issue described here: https://github.com/jacob2826/FreshRSS-TranslateTitlesCN/issues/6

This solution works only for Google Translate and was not intended as a deeper integration—just a few minutes of work to get something functional. If needed, I’m happy to collaborate further, but I’m confident that you can come up with a more robust and polished solution. 😊